### PR TITLE
Stop using world-related functions.

### DIFF
--- a/lootplot.main/shared/boot.lua
+++ b/lootplot.main/shared/boot.lua
@@ -69,12 +69,16 @@ local function initializeItems(plot, worldEnt)
     context:setDoomClock(dclock)
 end
 
-umg.on("@createWorld", function()
+if server then
+
+umg.on("@load", function()
     local ent = createWorld()
     local clientId = server.getHostClient()
     initializeSlots(clientId, ent.plot)
     initializeItems(ent.plot, ent)
 end)
+
+end
 
 umg.on("@playerJoin", function(clientId)
     local p = server.entities.player(clientId)

--- a/lootplot.test/shared/boot.lua
+++ b/lootplot.test/shared/boot.lua
@@ -18,7 +18,9 @@ local function createWorld()
     return wEnt
 end
 
-umg.on("@createWorld", createWorld)
+if server then
+    umg.on("@load", createWorld)
+end
 
 umg.on("@playerJoin", function(clientId)
     local w, h = testData.getPlotDimensions()

--- a/lootplot/server/item_validation.lua
+++ b/lootplot/server/item_validation.lua
@@ -41,7 +41,7 @@ end
 
 
 umg.on("@tick", scheduling.skip(3, function()
-    local time = umg.getWorldTime()
+    local time = love.timer.getTime()
     for _, itemEnt in ipairs(itemGroup)do
         local ppos = lp.getPos(itemEnt)
         if isInvalid(itemEnt, ppos) then

--- a/lootplot/shared/Pipeline.lua
+++ b/lootplot/shared/Pipeline.lua
@@ -15,7 +15,7 @@ function Pipeline:init()
 
     -- the time that we are allowed to execute the next obj in the pipeline.
     -- (used for delaying)
-    self.nextExecuteTime = umg.getWorldTime()
+    self.nextExecuteTime = love.timer.getTime()
 end
 
 
@@ -45,7 +45,7 @@ local function pollObj(self, obj)
 end
 
 function Pipeline:tick()
-    local time = umg.getWorldTime()
+    local time = love.timer.getTime()
     
     local buf = self.buffer
     while (time > self.nextExecuteTime) and (buf:size() > 0) do

--- a/spatial/shared/dimensions/dimensions.lua
+++ b/spatial/shared/dimensions/dimensions.lua
@@ -113,7 +113,7 @@ end
 
 if server then
     -- create the default dimension on start-up
-    umg.on("@createWorld", function()
+    umg.on("@load", function()
         dimensions.createDimension(constants.DEFAULT_DIMENSION)
     end)
 end

--- a/test/server/se.lua
+++ b/test/server/se.lua
@@ -34,7 +34,9 @@ local dim2 = "other"
 
 
 
-umg.on("@createWorld", function()
+if server then
+
+umg.on("@load", function()
     spatial.createDimension(dim2)
     borders.setBorder(dim2, {
         centerX = 0,
@@ -53,7 +55,7 @@ umg.on("@createWorld", function()
     end
 end)
 
-
+end
 
 
 


### PR DESCRIPTION
In particular, `umg.getWorldTime()` function and `@createWorld` event bus.