### PR TITLE
Additional debugging commands.

### DIFF
--- a/lootplot.main/shared/devtools.lua
+++ b/lootplot.main/shared/devtools.lua
@@ -16,6 +16,8 @@ But that's not really possible, because we don't know what plots exist;
 local runManager = require("shared.run_manager")
 
 
+if server then
+
 local function getPPos(clientId)
     local ctx = assert(lp.main.getRun())
     local plot = ctx:getPlot()
@@ -137,3 +139,5 @@ chat.handleCommand("crash", {
         umg.melt("manually initiated crash")
     end
 })
+
+end -- if server

--- a/lootplot.main/shared/devtools.lua
+++ b/lootplot.main/shared/devtools.lua
@@ -234,3 +234,72 @@ chat.handleCommand("debugEntity", {
         end
     end
 })
+
+
+
+local showEntIds = false
+
+chat.handleCommand("toggleEntIds", {
+    adminLevel = 0,
+    arguments = {},
+    handler = function()
+        showEntIds = not showEntIds
+    end
+})
+
+if client then
+
+local fonts = require("client.fonts")
+local smallFont = fonts.getSmallFont()
+
+---@param text string
+---@param x number
+---@param y number
+---@param rot number
+---@param sx number
+---@param sy number
+---@param oy number
+---@param kx number
+---@param ky number
+local function printCenterWithOutline(text, x, y, rot, sx, sy, oy, kx, ky)
+    local r, g, b, a = love.graphics.getColor()
+
+    love.graphics.setColor(0, 0, 0, a)
+    for outY = -1, 1 do
+        for outX = -1, 1 do
+            if not (outX == 0 and outY == 0) then
+                love.graphics.printf(
+                    text,
+                    smallFont,
+                    x + outX / 2,
+                    y + outY / 2,
+                    200,
+                    "center",
+                    rot,
+                    sx / 2,
+                    sy / 2,
+                    100,
+                    oy,
+                    kx,
+                    ky
+                )
+            end
+        end
+    end
+
+    love.graphics.setColor(r, g, b, a)
+    love.graphics.printf(text, smallFont, x, y, 200, "center", rot, sx / 2, sy / 2, 100, oy, kx, ky)
+end
+
+umg.on("rendering:drawEntity", 0x7fffffff, function(ent, x,y, rot, sx,sy, kx,ky)
+    if showEntIds then
+        if lp.isSlotEntity(ent) then
+            -- Slot is drawn differently
+            printCenterWithOutline(tostring(ent.id), x, y, rot, sx, sy, -18, kx, ky)
+        else
+            printCenterWithOutline(tostring(ent.id), x, y, rot, sx, sy, -7, kx, ky)
+        end
+    end
+end)
+
+end

--- a/lootplot.main/shared/devtools.lua
+++ b/lootplot.main/shared/devtools.lua
@@ -206,7 +206,7 @@ local function prettyPrintByLine(t, indent)
     end
 end
 
-chat.handleCommand("debugEntity", {
+chat.handleCommand("debugEnt", {
     adminLevel = 120,
     arguments = {
         {name = "entity", type = "number"},
@@ -302,4 +302,4 @@ umg.on("rendering:drawEntity", 0x7fffffff, function(ent, x,y, rot, sx,sy, kx,ky)
     end
 end)
 
-end
+end -- if client


### PR DESCRIPTION
* `/toggleEntIds` shows the entity IDs on the screen. Slot entity IDs are printed slightly below item entity IDs.
* `/debugEnt` dump the entity dat to the console, both server-side and client-side. Helps detecting desync issue.