### PR TITLE
Perform "Run Snapshot" When Performing Certain Actions

### DIFF
--- a/lootplot.main/entities/doom_gamemode/next_round.lua
+++ b/lootplot.main/entities/doom_gamemode/next_round.lua
@@ -17,8 +17,7 @@ local interp = localization.newInterpolator
 ---@param ppos lootplot.PPos
 local function startRound(ent, ppos)
     local plot = ppos:getPlot()
-    -- Need to snapshot the run first, otherwise the run
-    -- would try to serialize a function which UMG cannot do.
+    -- Ensure we have the run snapshot before starting round.
     runManager.snapshotRun()
 
     lp.queue(ppos, function()
@@ -34,8 +33,8 @@ local function startRound(ent, ppos)
         end)
         lp.addMoney(ent, 8)
 
-        -- Clear the snapshotted run.
-        runManager.clearSnapshot()
+        -- Snapshot the run again.
+        runManager.snapshotRun()
     end)
 
     -- pulse all slots:

--- a/lootplot.main/entities/doom_gamemode/next_round.lua
+++ b/lootplot.main/entities/doom_gamemode/next_round.lua
@@ -8,6 +8,8 @@ Progresses to next-round, be activating and resetting the whole slot.
 
 
 ]]
+local runManager = require("shared.run_manager")
+
 local loc = localization.localize
 local interp = localization.newInterpolator
 
@@ -15,6 +17,9 @@ local interp = localization.newInterpolator
 ---@param ppos lootplot.PPos
 local function startRound(ent, ppos)
     local plot = ppos:getPlot()
+    -- Need to snapshot the run first, otherwise the run
+    -- would try to serialize a function which UMG cannot do.
+    runManager.snapshotRun()
 
     lp.queue(ppos, function()
         if not umg.exists(ent) then
@@ -28,6 +33,9 @@ local function startRound(ent, ppos)
             lp.reset(ent)
         end)
         lp.addMoney(ent, 8)
+
+        -- Clear the snapshotted run.
+        runManager.clearSnapshot()
     end)
 
     -- pulse all slots:

--- a/lootplot.main/shared/Run.lua
+++ b/lootplot.main/shared/Run.lua
@@ -146,6 +146,10 @@ end
 
 if server then
 
+function Run:canSerialize()
+    return not self:getPlot():isPipelineRunning()
+end
+
 function Run:serialize()
     return umg.serialize(self)
 end

--- a/lootplot.main/shared/Run.lua
+++ b/lootplot.main/shared/Run.lua
@@ -151,6 +151,7 @@ function Run:canSerialize()
 end
 
 function Run:serialize()
+    assert(self:canSerialize(), "cannot serialize run while pipeline is running")
     return umg.serialize(self)
 end
 

--- a/lootplot.main/shared/run_manager.lua
+++ b/lootplot.main/shared/run_manager.lua
@@ -39,16 +39,28 @@ local function queryRunServer()
     -- }
 end
 
+---@type string?
+local runCache = nil
+
 ---@param run lootplot.main.Run
-local function saveRunServer(run)
-    local save = server.getSaveFilesystem()
+local function serializeRun(run)
     ---@class lootplot.main.RunSerialized
     local data = {
         runMeta = run:getMetadata(),
         runData = run:serialize(),
         rngState = lp.SEED:serializeToTable()
     }
-    save:write(RUN_FILENAME, umg.serialize(data))
+    return umg.serialize(data)
+end
+
+---@param run lootplot.main.Run
+local function saveRunServer(run)
+    local save = server.getSaveFilesystem()
+    if runCache then
+        save:write(RUN_FILENAME, runCache)
+    else
+        save:write(RUN_FILENAME, serializeRun(run))
+    end
 end
 
 
@@ -101,6 +113,18 @@ function runManager.saveRun()
     end
 
     return false
+end
+
+function runManager.snapshotRun()
+    local run = lp.main.getRun()
+
+    if run then
+        runCache = serializeRun(run)
+    end
+end
+
+function runManager.clearSnapshot()
+    runCache = nil
 end
 
 end -- if server

--- a/lootplot.main/shared/run_manager.lua
+++ b/lootplot.main/shared/run_manager.lua
@@ -56,11 +56,20 @@ end
 ---@param run lootplot.main.Run
 local function saveRunServer(run)
     local save = server.getSaveFilesystem()
+    local runSerialized
+
     if runCache then
-        save:write(RUN_FILENAME, runCache)
+        local success
+        success, runSerialized = pcall(serializeRun, run)
+        if not success then
+            runSerialized = runCache
+        end
     else
-        save:write(RUN_FILENAME, serializeRun(run))
+        -- Don't bother pcalling.
+        runSerialized = serializeRun(run)
     end
+
+    save:write(RUN_FILENAME, runSerialized)
 end
 
 
@@ -121,10 +130,6 @@ function runManager.snapshotRun()
     if run then
         runCache = serializeRun(run)
     end
-end
-
-function runManager.clearSnapshot()
-    runCache = nil
 end
 
 end -- if server


### PR DESCRIPTION
Snapshot the run when pressing "Next Round" and after the "Next Round" cycle finishes. This allows for more robustness when player quits the game and the run being saved.