### PR TITLE
Don't rely on love.timer.getTime() on pipeline.

### DIFF
--- a/lootplot.main/shared/Run.lua
+++ b/lootplot.main/shared/Run.lua
@@ -77,9 +77,10 @@ function Run:sync()
     end
 end
 
-function Run:tick()
+---@param dt number
+function Run:tick(dt)
     local plot = self:getPlot()
-    plot:tick()
+    plot:tick(dt)
 end
 
 ---@return lootplot.Plot

--- a/lootplot.main/shared/boot.lua
+++ b/lootplot.main/shared/boot.lua
@@ -23,12 +23,12 @@ end)
 
 
 
-umg.on("@tick", function()
+umg.on("@tick", function(dt)
     if server then
         local run = lp.main.getRun()
         if run then
             run:sync()
-            run:tick()
+            run:tick(dt)
         end
     end
 end)

--- a/lootplot/shared/Pipeline.lua
+++ b/lootplot/shared/Pipeline.lua
@@ -15,7 +15,7 @@ function Pipeline:init()
 
     -- the time that we are allowed to execute the next obj in the pipeline.
     -- (used for delaying)
-    self.nextExecuteTime = love.timer.getTime()
+    self.delay = 0
 end
 
 
@@ -33,22 +33,22 @@ function Pipeline:wait(delay)
     })
 end
 
-
+---@param self lootplot.Pipeline
 local function pollObj(self, obj)
     if obj.func then
         obj.func(unpack(obj.args))
     end
-    local time = love.timer.getTime()
+
     if obj.delay then
-        self.nextExecuteTime = time + obj.delay
+        self.delay = math.max(self.delay + obj.delay, 0)
     end
 end
 
-function Pipeline:tick()
-    local time = love.timer.getTime()
-    
+---@param dt number
+function Pipeline:tick(dt)
     local buf = self.buffer
-    while (time > self.nextExecuteTime) and (buf:size() > 0) do
+    self.delay = math.max(self.delay - dt, 0)
+    while self.delay <= 0 and buf:size() > 0 do
         local obj = buf:pop()
         pollObj(self, obj)
     end

--- a/lootplot/shared/Plot.lua
+++ b/lootplot/shared/Plot.lua
@@ -139,9 +139,10 @@ end
 
 umg.definePacket("lootplot:setPipelineRunningBool", {typelist = {ENT, BOOL}})
 
-function Plot:tick()
+---@param dt number
+function Plot:tick(dt)
     assert(server,"?")
-    self.pipeline:tick()
+    self.pipeline:tick(dt)
     local oldIsRunnin = self._cachedIsPipelineRunning
     local isRunnin = self:isPipelineRunning()
     if oldIsRunnin ~= isRunnin then


### PR DESCRIPTION
If player continues from long run, the pipeline won't start due to `nextExecutionTime` being very large.