### PR TITLE
localization infrastructure

### DIFF
--- a/localization/shared/exports.lua
+++ b/localization/shared/exports.lua
@@ -43,7 +43,7 @@ end
 
 ---Availability: Client and Server
 function Interpolator:__tostring()
-    return self.text
+    return string.format("localization:Interpolator %p: %s", self, self.text)
 end
 
 

--- a/localization/shared/exports.lua
+++ b/localization/shared/exports.lua
@@ -14,6 +14,9 @@ local interpolators = {}
 local EXPORT_ON_EXIT = true
 
 
+---@type table<string, table<string, string>>
+local translatedKeys = {}
+
 
 ---@class localization.InterpolatorObject: objects.Class
 local Interpolator = objects.Class("localization:Interpolator")
@@ -22,7 +25,12 @@ local Interpolator = objects.Class("localization:Interpolator")
 ---@param text string
 function Interpolator:init(modname, text, context)
     self.modname = modname
-    self.text = text
+
+    if translatedKeys[modname] and translatedKeys[modname][text] then
+        self.text = translatedKeys[modname][text]
+    else
+        self.text = text
+    end
 
     --[[
     dummy for now.
@@ -83,6 +91,53 @@ function localization.localize(text, variables, context)
     return localization.newInterpolator(text, context)(variables)
 end
 
+
+---@param modname string
+---@param fsysobj umg.FilesystemObject
+---@param path string
+local function tryLoad(modname, fsysobj, path)
+    if fsysobj:exists(path) then
+        local locData, err = fsysobj:read(path)
+        if locData then
+            local status, locs = pcall(json.decode, locData)
+            if status then
+                if not translatedKeys[modname] then
+                    translatedKeys[modname] = {}
+                end
+
+                -- TODO: Handle pluralization
+                for k, v in pairs(locs) do
+                    translatedKeys[modname][k] = v
+                end
+            else
+                umg.log.error("unable to load localization for mod '"..modname.."': "..locs)
+            end
+        else
+            umg.log.error("unable to load localization for mod '"..modname.."': "..err)
+        end
+    end
+end
+
+---Load localization data from filesystem object (callable only during initialization).
+---
+---Note: This currently does nothing server-side.
+---
+---Availability: Client and Server
+---@param fsysobj umg.FilesystemObject
+function localization.load(fsysobj)
+    if client then
+        local loadingContext = assert(umg.getLoadingContext(), "this can only be called at load-time")
+        local lang = client.getLanguage()
+
+        -- Localization file without country-specific code has lower priority.
+        local countryCodeOnly = lang:match("(%l%l)_%u%u")
+        if countryCodeOnly then
+            tryLoad(loadingContext.modname, fsysobj, countryCodeOnly..".json")
+        end
+
+        tryLoad(loadingContext.modname, fsysobj, lang..".json")
+    end
+end
 
 
 if EXPORT_ON_EXIT then


### PR DESCRIPTION
Uage: For each mod, they can place the localization JSON data anywhere. However they have to ensure `localization.load` is called for that particular mod before `localization.localize` (and thr `newInterpolator) is called. Otherwise wrong text will be picked up.

Example directory structure:
```
.
└── mod/
    ├── localization/
    │   ├── en_GB.json
    │   ├── id.json
    │   └── pt_BR.json
    └── localization_setup.lua
```
Where `localization_setup.lua` will contain:
```lua
localization.load(umg.getModFilesystem():cloneWithSubpath("localization"))
```
